### PR TITLE
Add support for the home API

### DIFF
--- a/aiofreepybox/__init__.py
+++ b/aiofreepybox/__init__.py
@@ -5,7 +5,7 @@ Provides authentification and row access to Freebox using Freebox OS developer A
 Freebox API documentation : http://dev.freebox.fr/sdk/os/
 '''
 
-__version__ = '0.0.7'
+__version__ = '0.0.8'
 __all__ = ['aiofreepybox']
 
 from aiofreepybox.aiofreepybox import Freepybox

--- a/aiofreepybox/access.py
+++ b/aiofreepybox/access.py
@@ -26,7 +26,7 @@ class Access:
 
         # raise exception if resp.success != True
         if not resp.get('success'):
-            raise AuthorizationError('Getting challenge failed (APIResponse: {0})'
+            raise AuthorizationError('Getting challenge failed (APIResponse: {})'
                                      .format(json.dumps(resp)))
 
         return resp['result']['challenge']
@@ -50,7 +50,7 @@ class Access:
 
         # raise exception if resp.success != True
         if not resp.get('success'):
-            raise AuthorizationError('Starting session failed (APIResponse: {0})'
+            raise AuthorizationError('Starting session failed (APIResponse: {})'
                                      .format(json.dumps(resp)))
 
         session_token = resp.get('result').get('session_token')
@@ -96,13 +96,14 @@ class Access:
             resp = await r.json()
 
             if resp.get('error_code') in ['auth_required', "invalid_session"]:
+                logger.debug('Invalid session')
                 await self._refresh_session_token()
                 request_params["headers"] = self._get_headers()
                 r = await verb(url, **request_params)
                 resp = await r.json()
 
             if not resp['success']:
-                errMsg = 'Request failed (APIResponse: {0})'.format(json.dumps(resp))
+                errMsg = 'Request failed (APIResponse: {})'.format(json.dumps(resp))
                 if resp.get('error_code') == 'insufficient_rights':
                     raise InsufficientPermissionsError(errMsg)
                 else:

--- a/aiofreepybox/aiofreepybox.py
+++ b/aiofreepybox/aiofreepybox.py
@@ -22,7 +22,7 @@ from aiofreepybox.api.fs import Fs
 from aiofreepybox.api.call import Call
 from aiofreepybox.api.connection import Connection
 from aiofreepybox.api.nat import Nat
-
+from aiofreepybox.api.home import Home
 
 # Token file default location
 token_filename = 'app_auth'
@@ -75,6 +75,7 @@ class Freepybox:
         self.call = Call(self._access)
         self.connection = Connection(self._access)
         self.nat = Nat(self._access)
+        self.home = Home(self._access)
 
     async def close(self):
         '''

--- a/aiofreepybox/api/home.py
+++ b/aiofreepybox/api/home.py
@@ -1,5 +1,4 @@
 # Home structure : adapter > node > endpoint
-
 class Home:
 
     def __init__(self, access):
@@ -47,11 +46,8 @@ class Home:
         '''
         return await self._access.get('home/tileset/', tileid)
 
-
     async def get_tilesets(self):
         '''
         Get the list of Tileset
         '''
         return await self._access.get('home/tileset/all')
-
-

--- a/aiofreepybox/api/home.py
+++ b/aiofreepybox/api/home.py
@@ -32,13 +32,13 @@ class Home:
         '''
         Set endpoint value
         '''
-        self._access.put('home/endpoints/{0}/'.format(node_id), endpoint_id, value)
+        self._access.put('home/endpoints/{0}/{1}'.format(node_id, endpoint_id), value)
 
     async def del_link(self, link_id):
         '''
         Delete link
         '''
-        return await self._access.delete('home/links/', link_id)
+        return await self._access.delete('home/links/{0}'.format(link_id))
 
     async def get_link(self, link_id):
         '''
@@ -56,7 +56,7 @@ class Home:
         '''
         Delete node id
         '''
-        return await self._access.delete('home/nodes/', node_id)
+        return await self._access.delete('home/nodes/{0}'.format(node_id))
 
     async def get_node(self, node_id):
         '''
@@ -68,7 +68,7 @@ class Home:
         '''
         Set node data
         '''
-        return await self._access.put('home/nodes/', node_id, node_data)
+        return await self._access.put('home/nodes/{0}'.format(node_id), node_data)
 
     async def get_nodes(self):
         '''
@@ -86,7 +86,7 @@ class Home:
         '''
         Set node rule
         '''
-        return await self._access.post('home/rules/', template_name, create_payload)
+        return await self._access.post('home/rules/{0}'.format(template_name), create_payload)
 
     async def get_rule_config(self, node_id, template_name, role_id):
         '''
@@ -98,7 +98,7 @@ class Home:
         '''
         Set node rule configuration data
         '''
-        self._access.put('home/rules/', rule_node_id, node_rule_data)
+        self._access.put('home/rules/{0}'.format(rule_node_id), node_rule_data)
 
     async def get_rules(self, node_id):
         '''
@@ -134,16 +134,16 @@ class Home:
         '''
         Start pairing step
         '''
-        return await self._access.post('home/pairing/', adapter_id, next_payload)
+        return await self._access.post('home/pairing/{0}'.format(adapter_id), next_payload)
 
     async def pairing_start(self, adapter_id, start_payload):
         '''
         Start pairing step
         '''
-        return await self._access.post('home/pairing/', adapter_id, start_payload)
+        return await self._access.post('home/pairing/{0}'.format(adapter_id), start_payload)
 
     async def pairing_stop(self, adapter_id, stop_payload):
         '''
         Stop pairing
         '''
-        return await self._access.post('home/pairing/', adapter_id, stop_payload)
+        return await self._access.post('home/pairing/{0}'.format(adapter_id), stop_payload)

--- a/aiofreepybox/api/home.py
+++ b/aiofreepybox/api/home.py
@@ -6,7 +6,7 @@ class Home:
 
     async def get_adapter(self, adapterid):
         '''
-        Retrieve the list of registered HomeAdapter
+        Retrieve a registered HomeAdapter
         '''
         return await self._access.get('home/adapters/', adapterid)
 
@@ -15,6 +15,12 @@ class Home:
         Retrieve the list of registered HomeAdapters
         '''
         return await self._access.get('home/adapters/')
+
+    async def get_camera(self):
+        '''
+        Get camera info
+        '''
+        return await self._access.get('camera/')
 
     async def get_endpointvalue(self, nodeid, endpointid):
         '''

--- a/aiofreepybox/api/home.py
+++ b/aiofreepybox/api/home.py
@@ -4,11 +4,11 @@ class Home:
     def __init__(self, access):
         self._access = access
 
-    async def get_adapter(self, adapterid):
+    async def get_adapter(self, adapter_id):
         '''
         Retrieve a registered HomeAdapter
         '''
-        return await self._access.get('home/adapters/', adapterid)
+        return await self._access.get('home/adapters/', adapter_id)
 
     async def get_adapters(self):
         '''
@@ -22,29 +22,29 @@ class Home:
         '''
         return await self._access.get('camera/')
 
-    async def get_endpoint_value(self, nodeid, endpointid):
+    async def get_endpoint_value(self, node_id, endpoint_id):
         '''
         Get endpoint value
         '''
-        return await self._access.get('home/endpoints/{0}/'.format(nodeid), endpointid)
+        return await self._access.get('home/endpoints/{0}/'.format(node_id), endpoint_id)
 
-    async def set_endpoint_value(self, nodeid, endpointid, value):
+    async def set_endpoint_value(self, node_id, endpoint_id, value):
         '''
         Set endpoint value
         '''
-        self._access.put('home/endpoints/{0}/'.format(nodeid), endpointid, value)
+        self._access.put('home/endpoints/{0}/'.format(node_id), endpoint_id, value)
 
-    async def del_link(self, linkid):
+    async def del_link(self, link_id):
         '''
         Delete link
         '''
-        return await self._access.delete('home/links/', linkid)
+        return await self._access.delete('home/links/', link_id)
 
-    async def get_link(self, linkid):
+    async def get_link(self, link_id):
         '''
         Get link
         '''
-        return await self._access.get('home/links/', linkid)
+        return await self._access.get('home/links/', link_id)
 
     async def get_links(self):
         '''
@@ -52,23 +52,23 @@ class Home:
         '''
         return await self._access.get('home/links/')
 
-    async def del_node(self, nodeid):
+    async def del_node(self, node_id):
         '''
         Delete node id
         '''
-        return await self._access.delete('home/nodes/', nodeid)
+        return await self._access.delete('home/nodes/', node_id)
 
-    async def get_node(self, nodeid):
+    async def get_node(self, node_id):
         '''
         Get node id
         '''
-        return await self._access.get('home/nodes/', nodeid)
+        return await self._access.get('home/nodes/', node_id)
 
-    async def set_node(self, nodeid, nodedata):
+    async def set_node(self, node_id, node_data):
         '''
         Set node data
         '''
-        return await self._access.put('home/nodes/', nodeid, nodedata)
+        return await self._access.put('home/nodes/', node_id, node_data)
 
     async def get_nodes(self):
         '''
@@ -76,35 +76,35 @@ class Home:
         '''
         return await self._access.get('home/nodes/')
 
-    async def get_pairing_state(self, adapterid):
+    async def get_pairing_state(self, adapter_id):
         '''
         Get the current pairing state
         '''
-        return await self._access.get('home/pairing/', adapterid)
+        return await self._access.get('home/pairing/', adapter_id)
 
-    async def set_rule(self, templatename, createpayload):
+    async def set_rule(self, template_name, create_payload):
         '''
         Set node rule
         '''
-        return await self._access.post('home/rules/', templatename, createpayload)
+        return await self._access.post('home/rules/', template_name, create_payload)
 
-    async def get_rule_config(self, nodeid, templatename, roleid):
+    async def get_rule_config(self, node_id, template_name, role_id):
         '''
         Get node rule configuration data
         '''
-        return await self._access.get('home/nodes/{0}/rules/template/{1}'.format(nodeid, templatename), roleid)
+        return await self._access.get('home/nodes/{0}/rules/template/{1}'.format(node_id, template_name), role_id)
 
-    async def set_rule_config(self, rulenodeid, noderuledata):
+    async def set_rule_config(self, rule_node_id, node_rule_data):
         '''
         Set node rule configuration data
         '''
-        self._access.put('home/rules/', rulenodeid, noderuledata)
+        self._access.put('home/rules/', rule_node_id, node_rule_data)
 
-    async def get_rules(self, nodeid):
+    async def get_rules(self, node_id):
         '''
         Get node rules
         '''
-        return await self._access.get('home/nodes/{0}/'.format(nodeid), 'rules')
+        return await self._access.get('home/nodes/{0}/'.format(node_id), 'rules')
 
     async def get_secmod(self):
         '''
@@ -118,11 +118,11 @@ class Home:
         '''
         return await self._access.get('home/sms/numbers')
 
-    async def get_tile(self, tileid):
+    async def get_tile(self, tile_id):
         '''
         Get the Tile with provided id
         '''
-        return await self._access.get('home/tileset/', tileid)
+        return await self._access.get('home/tileset/', tile_id)
 
     async def get_tilesets(self):
         '''
@@ -130,20 +130,20 @@ class Home:
         '''
         return await self._access.get('home/tileset/all')
 
-    async def pairing_next(self, adapterid, nextpayload):
+    async def pairing_next(self, adapter_id, next_payload):
         '''
         Start pairing step
         '''
-        return await self._access.post('home/pairing/', adapterid, nextpayload)
+        return await self._access.post('home/pairing/', adapter_id, next_payload)
 
-    async def pairing_start(self, adapterid, startpayload):
+    async def pairing_start(self, adapter_id, start_payload):
         '''
         Start pairing step
         '''
-        return await self._access.post('home/pairing/', adapterid, startpayload)
+        return await self._access.post('home/pairing/', adapter_id, start_payload)
 
-    async def pairing_stop(self, adapterid, stoppayload):
+    async def pairing_stop(self, adapter_id, stop_payload):
         '''
         Stop pairing
         '''
-        return await self._access.post('home/pairing/', adapterid, stoppayload)
+        return await self._access.post('home/pairing/', adapter_id, stop_payload)

--- a/aiofreepybox/api/home.py
+++ b/aiofreepybox/api/home.py
@@ -22,12 +22,6 @@ class Home:
         '''
         self._access.put('home/endpoints/{0}/'.format(nodeid), endpointid, value)
 
-    async def get_endpointvalues(self):
-        '''
-        Get endpoint values
-        '''
-        return await self._access.get('home/endpointvalues/')
-
     async def get_node(self, nodeid):
         '''
         Get node id

--- a/aiofreepybox/api/home.py
+++ b/aiofreepybox/api/home.py
@@ -8,7 +8,7 @@ class Home:
         '''
         Retrieve a registered HomeAdapter
         '''
-        return await self._access.get('home/adapters/', adapter_id)
+        return await self._access.get('home/adapters/{0}'.format(adapter_id))
 
     async def get_adapters(self):
         '''
@@ -26,7 +26,7 @@ class Home:
         '''
         Get endpoint value
         '''
-        return await self._access.get('home/endpoints/{0}/'.format(node_id), endpoint_id)
+        return await self._access.get('home/endpoints/{0}/{1}'.format(node_id, endpoint_id))
 
     async def set_endpoint_value(self, node_id, endpoint_id, value):
         '''
@@ -44,7 +44,7 @@ class Home:
         '''
         Get link
         '''
-        return await self._access.get('home/links/', link_id)
+        return await self._access.get('home/links/{0}'.format(link_id))
 
     async def get_links(self):
         '''
@@ -62,7 +62,7 @@ class Home:
         '''
         Get node id
         '''
-        return await self._access.get('home/nodes/', node_id)
+        return await self._access.get('home/nodes/{0}'.format(node_id))
 
     async def set_node(self, node_id, node_data):
         '''
@@ -80,7 +80,7 @@ class Home:
         '''
         Get the current pairing state
         '''
-        return await self._access.get('home/pairing/', adapter_id)
+        return await self._access.get('home/pairing/{0}'.format(adapter_id))
 
     async def set_rule(self, template_name, create_payload):
         '''
@@ -92,7 +92,7 @@ class Home:
         '''
         Get node rule configuration data
         '''
-        return await self._access.get('home/nodes/{0}/rules/template/{1}'.format(node_id, template_name), role_id)
+        return await self._access.get('home/nodes/{0}/rules/template/{1}/{2}'.format(node_id, template_name, role_id))
 
     async def set_rule_config(self, rule_node_id, node_rule_data):
         '''
@@ -104,7 +104,7 @@ class Home:
         '''
         Get node rules
         '''
-        return await self._access.get('home/nodes/{0}/'.format(node_id), 'rules')
+        return await self._access.get('home/nodes/{0}/rules'.format(node_id))
 
     async def get_secmod(self):
         '''
@@ -122,7 +122,7 @@ class Home:
         '''
         Get the Tile with provided id
         '''
-        return await self._access.get('home/tileset/', tile_id)
+        return await self._access.get('home/tileset/{0}'.format(tile_id))
 
     async def get_tilesets(self):
         '''

--- a/aiofreepybox/api/home.py
+++ b/aiofreepybox/api/home.py
@@ -4,17 +4,17 @@ class Home:
     def __init__(self, access):
         self._access = access
 
-    async def get_adapters(self):
-        '''
-        Retrieve the list of registered HomeAdapters
-        '''
-        return await self._access.get('home/adapters/')
-
     async def get_adapter(self, adapterid):
         '''
         Retrieve the list of registered HomeAdapters
         '''
         return await self._access.get('home/adapters/', adapterid)
+
+    async def get_adapters(self):
+        '''
+        Retrieve the list of registered HomeAdapters
+        '''
+        return await self._access.get('home/adapters/')
 
     async def get_endpointvalue(self, nodeid, endpointid):
         '''

--- a/aiofreepybox/api/home.py
+++ b/aiofreepybox/api/home.py
@@ -5,7 +5,7 @@ class Home:
         self._access = access
 
     home_endpoint_value_schema = {
-        'value': object
+        'value': None
     }
 
     create_home_node_rule_payload_schema = {
@@ -30,8 +30,8 @@ class Home:
     sms_number_data_schema = {
         'description': 'Mon numero',
         'phoneNumber': '',
-        'smsEnabled': bool(True),
-        'voicemailEnabled': bool(True)
+        'smsEnabled': True,
+        'voicemailEnabled': True
     }
 
     sms_validation_data_schema = {
@@ -45,12 +45,12 @@ class Home:
     next_pairing_step_payload_schema = {
         'session': 0,
         'pageid': 0,
-        'fields': [object]
+        'fields': [None]
     }
 
     start_pairing_step_payload_schema = {
-        'nfc': bool(True),
-        'qrcode': bool(),
+        'nfc': True,
+        'qrcode': False,
         'type': ''
     }
 
@@ -122,7 +122,7 @@ class Home:
         '''
         return await self._access.post('home/endpoints/get', endpoint_list)
 
-    async def set_home_endpoint_value(self, node_id, endpoint_id, home_endpoint_value=home_endpoint_value_schema):
+    async def set_home_endpoint_value(self, node_id, endpoint_id, home_endpoint_value):
         '''
         Set home endpoint value
         '''
@@ -170,7 +170,7 @@ class Home:
         '''
         return await self._access.get('home/nodes')
 
-    async def create_home_node_rule(self, template_name, create_home_node_rule_payload=create_home_node_rule_payload_schema):
+    async def create_home_node_rule(self, template_name, create_home_node_rule_payload):
         '''
         Create home node rule
         '''
@@ -188,7 +188,7 @@ class Home:
         '''
         return await self._access.get(f'home/nodes/{node_id}/rules/template/{template_name}/{role_id}')
 
-    async def set_home_node_rule_config(self, rule_node_id, node_rule_configuration_data=node_rule_configuration_data_schema):
+    async def set_home_node_rule_config(self, rule_node_id, node_rule_configuration_data):
         '''
         Set node rule configuration data
         '''
@@ -212,7 +212,7 @@ class Home:
         '''
         return await self._access.post('home/sms/numbers', sms_number_data)
 
-    async def edit_sms_number(self, sms_number_id, sms_number_data=sms_number_data_schema):
+    async def edit_sms_number(self, sms_number_id, sms_number_data):
         '''
         Edit sms number
         '''
@@ -224,13 +224,13 @@ class Home:
         '''
         return await self._access.get('home/sms/numbers')
 
-    async def send_sms_number_validation(self, sms_number_id, sms_validation_data=sms_validation_data_schema):
+    async def send_sms_number_validation(self, sms_number_id, sms_validation_data):
         '''
         Send sms number validation
         '''
         return await self._access.post(f'home/sms/numbers/{sms_number_id}/send_validation_sms', sms_validation_data)
 
-    async def validate_sms_number(self, sms_number_id, sms_number_validation_data=sms_number_validation_data_schema):
+    async def validate_sms_number(self, sms_number_id, sms_number_validation_data):
         '''
         Validate sms number
         '''
@@ -254,19 +254,19 @@ class Home:
         '''
         return await self._access.get(f'home/pairing/{home_adapter_id}')
 
-    async def next_home_pairing_step(self, home_adapter_id, next_pairing_step_payload=next_pairing_step_payload_schema):
+    async def next_home_pairing_step(self, home_adapter_id, next_pairing_step_payload):
         '''
         Next home pairing step
         '''
         return await self._access.post(f'home/pairing/{home_adapter_id}', next_pairing_step_payload)
 
-    async def start_home_pairing_step(self, home_adapter_id, start_pairing_step_payload=start_pairing_step_payload_schema):
+    async def start_home_pairing_step(self, home_adapter_id, start_pairing_step_payload):
         '''
         Start home pairing step
         '''
         return await self._access.post(f'home/pairing/{home_adapter_id}', start_pairing_step_payload)
 
-    async def stop_home_pairing_step(self, home_adapter_id, stop_pairing_step_payload=stop_pairing_step_payload_schema):
+    async def stop_home_pairing_step(self, home_adapter_id, stop_pairing_step_payload):
         '''
         Stop home pairing
         '''

--- a/aiofreepybox/api/home.py
+++ b/aiofreepybox/api/home.py
@@ -1,0 +1,57 @@
+# Home structure : adapter > node > endpoint
+
+class Home:
+
+    def __init__(self, access):
+        self._access = access
+
+    async def get_adapters(self):
+        '''
+        Retrieve the list of registered HomeAdapters
+        '''
+        return await self._access.get('home/adapters/')
+
+    async def get_endpointvalue(self, nodeid, endpointid):
+        '''
+        Get endpoint value
+        '''
+        return await self._access.get('home/endpoints/{0}/'.format(nodeid), endpointid)
+
+    async def set_endpointvalue(self, nodeid, endpointid, value):
+        '''
+        Set endpoint value
+        '''
+        self._access.put('home/endpoints/{0}/'.format(nodeid), endpointid, value)
+
+    async def get_endpointvalues(self):
+        '''
+        Get endpoint values
+        '''
+        return await self._access.get('home/endpointvalues/')
+
+    async def get_node(self, nodeid):
+        '''
+        Get node id
+        '''
+        return await self._access.get('home/nodes/', nodeid)
+
+    async def get_nodes(self):
+        '''
+        Get nodes
+        '''
+        return await self._access.get('home/nodes/')
+
+    async def get_tile(self, tileid):
+        '''
+        Get the Tile with provided id
+        '''
+        return await self._access.get('home/tileset/', tileid)
+
+
+    async def get_tilesets(self):
+        '''
+        Get the list of Tileset
+        '''
+        return await self._access.get('home/tileset/all')
+
+

--- a/aiofreepybox/api/home.py
+++ b/aiofreepybox/api/home.py
@@ -85,6 +85,10 @@ class Home:
     async def get_camera_snapshot(self, camera_index=0, size=4, quality=5):
         '''
         Get camera snapshot
+
+        `camera_index`: ``int``
+        `size`: 2 = 320x240, 3 = 640x480, 4 = 1280x720
+        `quality`: quality index, default is 5
         '''
         fbx_cameras = await self.get_camera()
         return await self._access.get(fbx_cameras[camera_index]['stream_url'].replace('stream.m3u8', f'snapshot.cgi?size={size}&quality={quality}')[1:])

--- a/aiofreepybox/api/home.py
+++ b/aiofreepybox/api/home.py
@@ -20,13 +20,13 @@ class Home:
         '''
         Retrieve the list of registered home adapters
         '''
-        return await self._access.get('home/adapters/')
+        return await self._access.get('home/adapters')
 
     async def get_camera(self):
         '''
         Get camera info
         '''
-        return await self._access.get('camera/')
+        return await self._access.get('camera')
 
     async def get_home_endpoint_value(self, node_id, endpoint_id):
         '''
@@ -62,7 +62,7 @@ class Home:
         '''
         Get home links
         '''
-        return await self._access.get('home/links/')
+        return await self._access.get('home/links')
 
     async def del_home_node(self, node_id):
         '''
@@ -86,7 +86,7 @@ class Home:
         '''
         Get home nodes
         '''
-        return await self._access.get('home/nodes/')
+        return await self._access.get('home/nodes')
 
     async def create_home_node_rule(self, template_name, create_home_node_payload):
         '''
@@ -122,7 +122,7 @@ class Home:
         '''
         Get security module
         '''
-        return await self._access.get('home/secmod/')
+        return await self._access.get('home/secmod')
 
     async def create_sms_number(self, sms_number_data):
         '''

--- a/aiofreepybox/api/home.py
+++ b/aiofreepybox/api/home.py
@@ -4,6 +4,60 @@ class Home:
     def __init__(self, access):
         self._access = access
 
+    home_endpoint_value_schema = {
+        'value': object
+    }
+
+    create_home_node_rule_payload_schema = {
+        'iconUrl': str(),
+        'id': int,
+        'label': str(),
+        'name': str(),
+        'role': int,
+        'roleLabel': str(),
+        'type': str()
+    }
+
+    node_rule_role_schema = {
+        'node': [int],
+        'role': int
+    }
+
+    node_rule_configuration_data_schema = {
+        'roles': [node_rule_role_schema]
+    }
+
+    sms_number_data_schema = {
+        'description': str('Mon numero'),
+        'phoneNumber': str(),
+        'smsEnabled': bool(True),
+        'voicemailEnabled': bool(True)
+    }
+
+    sms_validation_data_schema = {
+        'applicationHash': str()
+    }
+
+    sms_number_validation_data_schema = {
+        'validationCode': str()
+    }
+
+    next_pairing_step_payload_schema = {
+        'session': int,
+        'pageid': int,
+        'fields': [object]
+    }
+
+    start_pairing_step_payload_schema = {
+        'nfc': bool(True),
+        'qrcode': bool(),
+        'type': str()
+    }
+
+    stop_pairing_step_payload_schema = {
+        'session': int,
+    }
+
     async def del_home_adapter(self, home_adapter_id):
         '''
         Delete home adapter
@@ -40,11 +94,11 @@ class Home:
         '''
         return await self._access.post('home/endpoints/get', endpoint_list)
 
-    async def set_home_endpoint_value(self, node_id, endpoint_id, value):
+    async def set_home_endpoint_value(self, node_id, endpoint_id, home_endpoint_value=home_endpoint_value_schema):
         '''
         Set home endpoint value
         '''
-        return await self._access.put('home/endpoints/{0}/{1}'.format(node_id, endpoint_id), value)
+        return await self._access.put('home/endpoints/{0}/{1}'.format(node_id, endpoint_id), home_endpoint_value)
 
     async def del_home_link(self, link_id):
         '''
@@ -88,11 +142,11 @@ class Home:
         '''
         return await self._access.get('home/nodes')
 
-    async def create_home_node_rule(self, template_name, create_home_node_payload):
+    async def create_home_node_rule(self, template_name, create_home_node_rule_payload=create_home_node_rule_payload_schema):
         '''
         Create home node rule
         '''
-        return await self._access.post('home/rules/{0}'.format(template_name), create_home_node_payload)
+        return await self._access.post('home/rules/{0}'.format(template_name), create_home_node_rule_payload)
 
     async def get_home_node_existing_rule_config(self, node_id, rule_node_id, role_id):
         '''
@@ -106,11 +160,11 @@ class Home:
         '''
         return await self._access.get('home/nodes/{0}/rules/template/{1}/{2}'.format(node_id, template_name, role_id))
 
-    async def set_home_node_rule_config(self, rule_node_id, node_rule_data):
+    async def set_home_node_rule_config(self, rule_node_id, node_rule_configuration_data=node_rule_configuration_data_schema):
         '''
         Set node rule configuration data
         '''
-        return await self._access.put('home/rules/{0}'.format(rule_node_id), node_rule_data)
+        return await self._access.put('home/rules/{0}'.format(rule_node_id), node_rule_configuration_data)
 
     async def get_home_node_new_rules(self, node_id):
         '''
@@ -130,7 +184,7 @@ class Home:
         '''
         return await self._access.post('home/sms/numbers', sms_number_data)
 
-    async def edit_sms_number(self, sms_number_id, sms_number_data):
+    async def edit_sms_number(self, sms_number_id, sms_number_data=sms_number_data_schema):
         '''
         Edit sms number
         '''
@@ -142,13 +196,13 @@ class Home:
         '''
         return await self._access.get('home/sms/numbers')
 
-    async def send_sms_number_validation(self, sms_number_id, sms_validation_data):
+    async def send_sms_number_validation(self, sms_number_id, sms_validation_data=sms_validation_data_schema):
         '''
         Send sms number validation
         '''
         return await self._access.post('home/sms/numbers/{0}/send_validation_sms'.format(sms_number_id), sms_validation_data)
 
-    async def validate_sms_number(self, sms_number_id, sms_number_validation_data):
+    async def validate_sms_number(self, sms_number_id, sms_number_validation_data=sms_number_validation_data_schema):
         '''
         Validate sms number
         '''
@@ -172,19 +226,19 @@ class Home:
         '''
         return await self._access.get('home/pairing/{0}'.format(home_adapter_id))
 
-    async def next_home_pairing_step(self, home_adapter_id, next_pairing_step_payload):
+    async def next_home_pairing_step(self, home_adapter_id, next_pairing_step_payload=next_pairing_step_payload_schema):
         '''
         Next home pairing step
         '''
         return await self._access.post('home/pairing/{0}'.format(home_adapter_id), next_pairing_step_payload)
 
-    async def start_home_pairing_step(self, home_adapter_id, start_pairing_step_payload):
+    async def start_home_pairing_step(self, home_adapter_id, start_pairing_step_payload=start_pairing_step_payload_schema):
         '''
         Start home pairing step
         '''
         return await self._access.post('home/pairing/{0}'.format(home_adapter_id), start_pairing_step_payload)
 
-    async def stop_home_pairing_step(self, home_adapter_id, stop_pairing_step_payload):
+    async def stop_home_pairing_step(self, home_adapter_id, stop_pairing_step_payload=stop_pairing_step_payload_schema):
         '''
         Stop home pairing
         '''

--- a/aiofreepybox/api/home.py
+++ b/aiofreepybox/api/home.py
@@ -6,7 +6,7 @@ class Home:
 
     async def get_adapter(self, adapterid):
         '''
-        Retrieve the list of registered HomeAdapters
+        Retrieve the list of registered HomeAdapter
         '''
         return await self._access.get('home/adapters/', adapterid)
 
@@ -39,6 +39,12 @@ class Home:
         Get nodes
         '''
         return await self._access.get('home/nodes/')
+
+    async def get_pairingstep(self, adapterid):
+        '''
+        Get the current pairing step
+        '''
+        return await self._access.get('home/pairing/', adapterid)
 
     async def get_tile(self, tileid):
         '''

--- a/aiofreepybox/api/home.py
+++ b/aiofreepybox/api/home.py
@@ -92,6 +92,9 @@ class Home:
     async def get_camera_stream_m3u8(self, camera_index=0, channel=2):
         '''
         Get camera stream
+
+        `camera_index`: ``int``
+        `channel`: 1 is SD, 2 is HD
         '''
         fbx_cameras = await self.get_camera()
         return await self._access.get(fbx_cameras[camera_index]['stream_url'].replace('stream.m3u8', f'stream.m3u8?channel={channel}')[1:])

--- a/aiofreepybox/api/home.py
+++ b/aiofreepybox/api/home.py
@@ -6,13 +6,13 @@ class Home:
 
     async def get_adapter(self, adapter_id):
         '''
-        Retrieve a registered HomeAdapter
+        Retrieve a registered home adapter
         '''
         return await self._access.get('home/adapters/{0}'.format(adapter_id))
 
     async def get_adapters(self):
         '''
-        Retrieve the list of registered HomeAdapters
+        Retrieve the list of registered home adapters
         '''
         return await self._access.get('home/adapters/')
 
@@ -120,13 +120,13 @@ class Home:
 
     async def get_tile(self, tile_id):
         '''
-        Get the Tile with provided id
+        Get the tile with provided id
         '''
         return await self._access.get('home/tileset/{0}'.format(tile_id))
 
     async def get_tilesets(self):
         '''
-        Get the list of Tileset
+        Get the list of tileset
         '''
         return await self._access.get('home/tileset/all')
 

--- a/aiofreepybox/api/home.py
+++ b/aiofreepybox/api/home.py
@@ -9,13 +9,13 @@ class Home:
     }
 
     create_home_node_rule_payload_schema = {
-        'iconUrl': str(),
+        'iconUrl': '',
         'id': int,
-        'label': str(),
-        'name': str(),
+        'label': '',
+        'name': '',
         'role': int,
-        'roleLabel': str(),
-        'type': str()
+        'roleLabel': '',
+        'type': ''
     }
 
     node_rule_role_schema = {
@@ -28,18 +28,18 @@ class Home:
     }
 
     sms_number_data_schema = {
-        'description': str('Mon numero'),
-        'phoneNumber': str(),
+        'description': 'Mon numero',
+        'phoneNumber': '',
         'smsEnabled': bool(True),
         'voicemailEnabled': bool(True)
     }
 
     sms_validation_data_schema = {
-        'applicationHash': str()
+        'applicationHash': ''
     }
 
     sms_number_validation_data_schema = {
-        'validationCode': str()
+        'validationCode': ''
     }
 
     next_pairing_step_payload_schema = {
@@ -51,7 +51,7 @@ class Home:
     start_pairing_step_payload_schema = {
         'nfc': bool(True),
         'qrcode': bool(),
-        'type': str()
+        'type': ''
     }
 
     stop_pairing_step_payload_schema = {
@@ -62,13 +62,13 @@ class Home:
         '''
         Delete home adapter
         '''
-        return await self._access.delete('home/adapters/{0}'.format(home_adapter_id))
+        return await self._access.delete(f'home/adapters/{home_adapter_id}')
 
     async def get_home_adapter(self, home_adapter_id):
         '''
         Retrieve a registered home adapter
         '''
-        return await self._access.get('home/adapters/{0}'.format(home_adapter_id))
+        return await self._access.get(f'home/adapters/{home_adapter_id}')
 
     async def get_home_adapters(self):
         '''
@@ -87,27 +87,27 @@ class Home:
         Get camera snapshot
         '''
         fbx_cameras = await self.get_camera()
-        return await self._access.get(fbx_cameras[camera_index]['stream_url'].replace('stream.m3u8', 'snapshot.cgi?size={0}&quality={1}'.format(size, quality))[1:])
+        return await self._access.get(fbx_cameras[camera_index]['stream_url'].replace('stream.m3u8', f'snapshot.cgi?size={size}&quality={quality}')[1:])
 
     async def get_camera_stream_m3u8(self, camera_index=0, channel=2):
         '''
         Get camera stream
         '''
         fbx_cameras = await self.get_camera()
-        return await self._access.get(fbx_cameras[camera_index]['stream_url'].replace('stream.m3u8', 'stream.m3u8?channel={0}'.format(channel))[1:])
+        return await self._access.get(fbx_cameras[camera_index]['stream_url'].replace('stream.m3u8', f'stream.m3u8?channel={channel}')[1:])
 
     async def get_camera_ts(self, ts_name, camera_index=0):
         '''
         Get camera stream
         '''
         fbx_cameras = await self.get_camera()
-        return await self._access.get(fbx_cameras[camera_index]['stream_url'].replace('stream.m3u8', '{0}'.format(ts_name))[1:])
+        return await self._access.get(fbx_cameras[camera_index]['stream_url'].replace('stream.m3u8', f'{ts_name}')[1:])
 
     async def get_home_endpoint_value(self, node_id, endpoint_id):
         '''
         Get home endpoint value
         '''
-        return await self._access.get('home/endpoints/{0}/{1}'.format(node_id, endpoint_id))
+        return await self._access.get(f'home/endpoints/{node_id}/{endpoint_id}')
 
     async def get_home_endpoint_values(self, endpoint_list):
         '''
@@ -119,19 +119,19 @@ class Home:
         '''
         Set home endpoint value
         '''
-        return await self._access.put('home/endpoints/{0}/{1}'.format(node_id, endpoint_id), home_endpoint_value)
+        return await self._access.put(f'home/endpoints/{node_id}/{endpoint_id}', home_endpoint_value)
 
     async def del_home_link(self, link_id):
         '''
         Delete home link
         '''
-        return await self._access.delete('home/links/{0}'.format(link_id))
+        return await self._access.delete(f'home/links/{link_id}')
 
     async def get_home_link(self, link_id):
         '''
         Get home link
         '''
-        return await self._access.get('home/links/{0}'.format(link_id))
+        return await self._access.get(f'home/links/{link_id}')
 
     async def get_home_links(self):
         '''
@@ -143,19 +143,19 @@ class Home:
         '''
         Delete home node id
         '''
-        return await self._access.delete('home/nodes/{0}'.format(node_id))
+        return await self._access.delete(f'home/nodes/{node_id}')
 
     async def get_home_node(self, node_id):
         '''
         Get home node id
         '''
-        return await self._access.get('home/nodes/{0}'.format(node_id))
+        return await self._access.get(f'home/nodes/{node_id}')
 
     async def edit_home_node(self, node_id, node_data):
         '''
         Edit home node data
         '''
-        return await self._access.put('home/nodes/{0}'.format(node_id), node_data)
+        return await self._access.put(f'home/nodes/{node_id}', node_data)
 
     async def get_home_nodes(self):
         '''
@@ -167,31 +167,31 @@ class Home:
         '''
         Create home node rule
         '''
-        return await self._access.post('home/rules/{0}'.format(template_name), create_home_node_rule_payload)
+        return await self._access.post(f'home/rules/{template_name}', create_home_node_rule_payload)
 
     async def get_home_node_existing_rule_config(self, node_id, rule_node_id, role_id):
         '''
         Get home node existing rule configuration data
         '''
-        return await self._access.get('home/nodes/{0}/rules/node/{1}/{2}'.format(node_id, rule_node_id, role_id))
+        return await self._access.get(f'home/nodes/{node_id}/rules/node/{rule_node_id}/{role_id}')
 
     async def get_home_node_template_rule_config(self, node_id, template_name, role_id):
         '''
         Get node rule template configuration data
         '''
-        return await self._access.get('home/nodes/{0}/rules/template/{1}/{2}'.format(node_id, template_name, role_id))
+        return await self._access.get(f'home/nodes/{node_id}/rules/template/{template_name}/{role_id}')
 
     async def set_home_node_rule_config(self, rule_node_id, node_rule_configuration_data=node_rule_configuration_data_schema):
         '''
         Set node rule configuration data
         '''
-        return await self._access.put('home/rules/{0}'.format(rule_node_id), node_rule_configuration_data)
+        return await self._access.put(f'home/rules/{rule_node_id}', node_rule_configuration_data)
 
     async def get_home_node_new_rules(self, node_id):
         '''
         Get node new rules
         '''
-        return await self._access.get('home/nodes/{0}/rules'.format(node_id))
+        return await self._access.get(f'home/nodes/{node_id}/rules')
 
     async def get_secmod(self):
         '''
@@ -209,7 +209,7 @@ class Home:
         '''
         Edit sms number
         '''
-        return await self._access.put('home/sms/numbers/{0}'.format(sms_number_id), sms_number_data)
+        return await self._access.put(f'home/sms/numbers/{sms_number_id}', sms_number_data)
 
     async def get_sms_numbers(self):
         '''
@@ -221,19 +221,19 @@ class Home:
         '''
         Send sms number validation
         '''
-        return await self._access.post('home/sms/numbers/{0}/send_validation_sms'.format(sms_number_id), sms_validation_data)
+        return await self._access.post(f'home/sms/numbers/{sms_number_id}/send_validation_sms', sms_validation_data)
 
     async def validate_sms_number(self, sms_number_id, sms_number_validation_data=sms_number_validation_data_schema):
         '''
         Validate sms number
         '''
-        return await self._access.post('home/sms/numbers/{0}/validate'.format(sms_number_id), sms_number_validation_data)
+        return await self._access.post(f'home/sms/numbers/{sms_number_id}/validate', sms_number_validation_data)
 
     async def get_home_tile(self, tile_id):
         '''
         Get the home tile with provided id
         '''
-        return await self._access.get('home/tileset/{0}'.format(tile_id))
+        return await self._access.get(f'home/tileset/{tile_id}')
 
     async def get_home_tilesets(self):
         '''
@@ -245,22 +245,22 @@ class Home:
         '''
         Get the current home pairing state
         '''
-        return await self._access.get('home/pairing/{0}'.format(home_adapter_id))
+        return await self._access.get(f'home/pairing/{home_adapter_id}')
 
     async def next_home_pairing_step(self, home_adapter_id, next_pairing_step_payload=next_pairing_step_payload_schema):
         '''
         Next home pairing step
         '''
-        return await self._access.post('home/pairing/{0}'.format(home_adapter_id), next_pairing_step_payload)
+        return await self._access.post(f'home/pairing/{home_adapter_id}', next_pairing_step_payload)
 
     async def start_home_pairing_step(self, home_adapter_id, start_pairing_step_payload=start_pairing_step_payload_schema):
         '''
         Start home pairing step
         '''
-        return await self._access.post('home/pairing/{0}'.format(home_adapter_id), start_pairing_step_payload)
+        return await self._access.post(f'home/pairing/{home_adapter_id}', start_pairing_step_payload)
 
     async def stop_home_pairing_step(self, home_adapter_id, stop_pairing_step_payload=stop_pairing_step_payload_schema):
         '''
         Stop home pairing
         '''
-        return await self._access.post('home/pairing/{0}'.format(home_adapter_id), stop_pairing_step_payload)
+        return await self._access.post(f'home/pairing/{home_adapter_id}', stop_pairing_step_payload)

--- a/aiofreepybox/api/home.py
+++ b/aiofreepybox/api/home.py
@@ -28,11 +28,41 @@ class Home:
         '''
         self._access.put('home/endpoints/{0}/'.format(nodeid), endpointid, value)
 
+    async def del_link(self, linkid):
+        '''
+        Delete link
+        '''
+        return await self._access.delete('home/links/', linkid)
+
+    async def get_link(self, linkid):
+        '''
+        Get link
+        '''
+        return await self._access.get('home/links/', linkid)
+
+    async def get_links(self):
+        '''
+        Get links
+        '''
+        return await self._access.get('home/links/')
+
+    async def del_node(self, nodeid):
+        '''
+        Delete node id
+        '''
+        return await self._access.delete('home/nodes/', nodeid)
+
     async def get_node(self, nodeid):
         '''
         Get node id
         '''
         return await self._access.get('home/nodes/', nodeid)
+
+    async def set_node(self, nodeid, nodedata):
+        '''
+        Set node data
+        '''
+        return await self._access.put('home/nodes/', nodeid, nodedata)
 
     async def get_nodes(self):
         '''
@@ -40,11 +70,47 @@ class Home:
         '''
         return await self._access.get('home/nodes/')
 
-    async def get_pairingstep(self, adapterid):
+    async def get_pairingstate(self, adapterid):
         '''
-        Get the current pairing step
+        Get the current pairing state
         '''
         return await self._access.get('home/pairing/', adapterid)
+
+    async def set_rule(self, templatename, createpayload):
+        '''
+        Set node rule
+        '''
+        return await self._access.post('home/rules/', templatename, createpayload)
+
+    async def get_ruleconfig(self, nodeid, templatename, roleid):
+        '''
+        Get node rule configuration data
+        '''
+        return await self._access.get('home/nodes/{0}/rules/template/{1}'.format(nodeid, templatename), roleid)
+
+    async def set_ruleconfig(self, rulenodeid, noderuledata):
+        '''
+        Set node rule configuration data
+        '''
+        self._access.put('home/rules/', rulenodeid, noderuledata)
+
+    async def get_rules(self, nodeid):
+        '''
+        Get node rules
+        '''
+        return await self._access.get('home/nodes/{0}/'.format(nodeid), 'rules')
+
+    async def get_secmod(self):
+        '''
+        Get security module
+        '''
+        return await self._access.get('home/secmod/')
+
+    async def get_smsnumbers(self):
+        '''
+        Get sms numbers
+        '''
+        return await self._access.get('home/sms/numbers')
 
     async def get_tile(self, tileid):
         '''
@@ -57,3 +123,21 @@ class Home:
         Get the list of Tileset
         '''
         return await self._access.get('home/tileset/all')
+
+    async def pairing_next(self, adapterid, nextpayload):
+        '''
+        Start pairing step
+        '''
+        return await self._access.post('home/pairing/', adapterid, nextpayload)
+
+    async def pairing_start(self, adapterid, startpayload):
+        '''
+        Start pairing step
+        '''
+        return await self._access.post('home/pairing/', adapterid, startpayload)
+
+    async def pairing_stop(self, adapterid, stoppayload):
+        '''
+        Stop pairing
+        '''
+        return await self._access.post('home/pairing/', adapterid, stoppayload)

--- a/aiofreepybox/api/home.py
+++ b/aiofreepybox/api/home.py
@@ -59,215 +59,215 @@ class Home:
     }
 
     async def del_home_adapter(self, home_adapter_id):
-        '''
+        """
         Delete home adapter
-        '''
+        """
         return await self._access.delete(f'home/adapters/{home_adapter_id}')
 
     async def get_home_adapter(self, home_adapter_id):
-        '''
+        """
         Retrieve a registered home adapter
-        '''
+        """
         return await self._access.get(f'home/adapters/{home_adapter_id}')
 
     async def get_home_adapters(self):
-        '''
+        """
         Retrieve the list of registered home adapters
-        '''
+        """
         return await self._access.get('home/adapters')
 
     async def get_camera(self):
-        '''
+        """
         Get camera info
-        '''
+        """
         return await self._access.get('camera')
 
     async def get_camera_snapshot(self, camera_index=0, size=4, quality=5):
-        '''
+        """
         Get camera snapshot
 
         `camera_index`: ``int``
         `size`: 2 = 320x240, 3 = 640x480, 4 = 1280x720
         `quality`: quality index, default is 5
-        '''
+        """
         fbx_cameras = await self.get_camera()
         return await self._access.get(fbx_cameras[camera_index]['stream_url'].replace('stream.m3u8', f'snapshot.cgi?size={size}&quality={quality}')[1:])
 
     async def get_camera_stream_m3u8(self, camera_index=0, channel=2):
-        '''
+        """
         Get camera stream
 
         `camera_index`: ``int``
         `channel`: 1 is SD, 2 is HD
-        '''
+        """
         fbx_cameras = await self.get_camera()
         return await self._access.get(fbx_cameras[camera_index]['stream_url'].replace('stream.m3u8', f'stream.m3u8?channel={channel}')[1:])
 
     async def get_camera_ts(self, ts_name, camera_index=0):
-        '''
+        """
         Get camera stream
-        '''
+        """
         fbx_cameras = await self.get_camera()
         return await self._access.get(fbx_cameras[camera_index]['stream_url'].replace('stream.m3u8', f'{ts_name}')[1:])
 
     async def get_home_endpoint_value(self, node_id, endpoint_id):
-        '''
+        """
         Get home endpoint value
-        '''
+        """
         return await self._access.get(f'home/endpoints/{node_id}/{endpoint_id}')
 
     async def get_home_endpoint_values(self, endpoint_list):
-        '''
+        """
         Get home endpoint values
-        '''
+        """
         return await self._access.post('home/endpoints/get', endpoint_list)
 
     async def set_home_endpoint_value(self, node_id, endpoint_id, home_endpoint_value):
-        '''
+        """
         Set home endpoint value
-        '''
+        """
         return await self._access.put(f'home/endpoints/{node_id}/{endpoint_id}', home_endpoint_value)
 
     async def del_home_link(self, link_id):
-        '''
+        """
         Delete home link
-        '''
+        """
         return await self._access.delete(f'home/links/{link_id}')
 
     async def get_home_link(self, link_id):
-        '''
+        """
         Get home link
-        '''
+        """
         return await self._access.get(f'home/links/{link_id}')
 
     async def get_home_links(self):
-        '''
+        """
         Get home links
-        '''
+        """
         return await self._access.get('home/links')
 
     async def del_home_node(self, node_id):
-        '''
+        """
         Delete home node id
-        '''
+        """
         return await self._access.delete(f'home/nodes/{node_id}')
 
     async def get_home_node(self, node_id):
-        '''
+        """
         Get home node id
-        '''
+        """
         return await self._access.get(f'home/nodes/{node_id}')
 
     async def edit_home_node(self, node_id, node_data):
-        '''
+        """
         Edit home node data
-        '''
+        """
         return await self._access.put(f'home/nodes/{node_id}', node_data)
 
     async def get_home_nodes(self):
-        '''
+        """
         Get home nodes
-        '''
+        """
         return await self._access.get('home/nodes')
 
     async def create_home_node_rule(self, template_name, create_home_node_rule_payload):
-        '''
+        """
         Create home node rule
-        '''
+        """
         return await self._access.post(f'home/rules/{template_name}', create_home_node_rule_payload)
 
     async def get_home_node_existing_rule_config(self, node_id, rule_node_id, role_id):
-        '''
+        """
         Get home node existing rule configuration data
-        '''
+        """
         return await self._access.get(f'home/nodes/{node_id}/rules/node/{rule_node_id}/{role_id}')
 
     async def get_home_node_template_rule_config(self, node_id, template_name, role_id):
-        '''
+        """
         Get node rule template configuration data
-        '''
+        """
         return await self._access.get(f'home/nodes/{node_id}/rules/template/{template_name}/{role_id}')
 
     async def set_home_node_rule_config(self, rule_node_id, node_rule_configuration_data):
-        '''
+        """
         Set node rule configuration data
-        '''
+        """
         return await self._access.put(f'home/rules/{rule_node_id}', node_rule_configuration_data)
 
     async def get_home_node_new_rules(self, node_id):
-        '''
+        """
         Get node new rules
-        '''
+        """
         return await self._access.get(f'home/nodes/{node_id}/rules')
 
     async def get_secmod(self):
-        '''
+        """
         Get security module
-        '''
+        """
         return await self._access.get('home/secmod')
 
     async def create_sms_number(self, sms_number_data):
-        '''
+        """
         Create sms number
-        '''
+        """
         return await self._access.post('home/sms/numbers', sms_number_data)
 
     async def edit_sms_number(self, sms_number_id, sms_number_data):
-        '''
+        """
         Edit sms number
-        '''
+        """
         return await self._access.put(f'home/sms/numbers/{sms_number_id}', sms_number_data)
 
     async def get_sms_numbers(self):
-        '''
+        """
         Get sms numbers
-        '''
+        """
         return await self._access.get('home/sms/numbers')
 
     async def send_sms_number_validation(self, sms_number_id, sms_validation_data):
-        '''
+        """
         Send sms number validation
-        '''
+        """
         return await self._access.post(f'home/sms/numbers/{sms_number_id}/send_validation_sms', sms_validation_data)
 
     async def validate_sms_number(self, sms_number_id, sms_number_validation_data):
-        '''
+        """
         Validate sms number
-        '''
+        """
         return await self._access.post(f'home/sms/numbers/{sms_number_id}/validate', sms_number_validation_data)
 
     async def get_home_tile(self, tile_id):
-        '''
+        """
         Get the home tile with provided id
-        '''
+        """
         return await self._access.get(f'home/tileset/{tile_id}')
 
     async def get_home_tilesets(self):
-        '''
+        """
         Get the list of home tileset
-        '''
+        """
         return await self._access.get('home/tileset/all')
 
     async def get_home_pairing_state(self, home_adapter_id):
-        '''
+        """
         Get the current home pairing state
-        '''
+        """
         return await self._access.get(f'home/pairing/{home_adapter_id}')
 
     async def next_home_pairing_step(self, home_adapter_id, next_pairing_step_payload):
-        '''
+        """
         Next home pairing step
-        '''
+        """
         return await self._access.post(f'home/pairing/{home_adapter_id}', next_pairing_step_payload)
 
     async def start_home_pairing_step(self, home_adapter_id, start_pairing_step_payload):
-        '''
+        """
         Start home pairing step
-        '''
+        """
         return await self._access.post(f'home/pairing/{home_adapter_id}', start_pairing_step_payload)
 
     async def stop_home_pairing_step(self, home_adapter_id, stop_pairing_step_payload):
-        '''
+        """
         Stop home pairing
-        '''
+        """
         return await self._access.post(f'home/pairing/{home_adapter_id}', stop_pairing_step_payload)

--- a/aiofreepybox/api/home.py
+++ b/aiofreepybox/api/home.py
@@ -4,13 +4,19 @@ class Home:
     def __init__(self, access):
         self._access = access
 
-    async def get_adapter(self, adapter_id):
+    async def del_home_adapter(self, home_adapter_id):
+        '''
+        Delete home adapter
+        '''
+        return await self._access.delete('home/adapters/{0}'.format(home_adapter_id))
+
+    async def get_home_adapter(self, home_adapter_id):
         '''
         Retrieve a registered home adapter
         '''
-        return await self._access.get('home/adapters/{0}'.format(adapter_id))
+        return await self._access.get('home/adapters/{0}'.format(home_adapter_id))
 
-    async def get_adapters(self):
+    async def get_home_adapters(self):
         '''
         Retrieve the list of registered home adapters
         '''
@@ -22,87 +28,93 @@ class Home:
         '''
         return await self._access.get('camera/')
 
-    async def get_endpoint_value(self, node_id, endpoint_id):
+    async def get_home_endpoint_value(self, node_id, endpoint_id):
         '''
-        Get endpoint value
+        Get home endpoint value
         '''
         return await self._access.get('home/endpoints/{0}/{1}'.format(node_id, endpoint_id))
 
-    async def set_endpoint_value(self, node_id, endpoint_id, value):
+    async def get_home_endpoint_values(self, endpoint_list):
         '''
-        Set endpoint value
+        Get home endpoint values
         '''
-        self._access.put('home/endpoints/{0}/{1}'.format(node_id, endpoint_id), value)
+        return await self._access.post('home/endpoints/get', endpoint_list)
 
-    async def del_link(self, link_id):
+    async def set_home_endpoint_value(self, node_id, endpoint_id, value):
         '''
-        Delete link
+        Set home endpoint value
+        '''
+        return await self._access.put('home/endpoints/{0}/{1}'.format(node_id, endpoint_id), value)
+
+    async def del_home_link(self, link_id):
+        '''
+        Delete home link
         '''
         return await self._access.delete('home/links/{0}'.format(link_id))
 
-    async def get_link(self, link_id):
+    async def get_home_link(self, link_id):
         '''
-        Get link
+        Get home link
         '''
         return await self._access.get('home/links/{0}'.format(link_id))
 
-    async def get_links(self):
+    async def get_home_links(self):
         '''
-        Get links
+        Get home links
         '''
         return await self._access.get('home/links/')
 
-    async def del_node(self, node_id):
+    async def del_home_node(self, node_id):
         '''
-        Delete node id
+        Delete home node id
         '''
         return await self._access.delete('home/nodes/{0}'.format(node_id))
 
-    async def get_node(self, node_id):
+    async def get_home_node(self, node_id):
         '''
-        Get node id
+        Get home node id
         '''
         return await self._access.get('home/nodes/{0}'.format(node_id))
 
-    async def set_node(self, node_id, node_data):
+    async def edit_home_node(self, node_id, node_data):
         '''
-        Set node data
+        Edit home node data
         '''
         return await self._access.put('home/nodes/{0}'.format(node_id), node_data)
 
-    async def get_nodes(self):
+    async def get_home_nodes(self):
         '''
-        Get nodes
+        Get home nodes
         '''
         return await self._access.get('home/nodes/')
 
-    async def get_pairing_state(self, adapter_id):
+    async def create_home_node_rule(self, template_name, create_home_node_payload):
         '''
-        Get the current pairing state
+        Create home node rule
         '''
-        return await self._access.get('home/pairing/{0}'.format(adapter_id))
+        return await self._access.post('home/rules/{0}'.format(template_name), create_home_node_payload)
 
-    async def set_rule(self, template_name, create_payload):
+    async def get_home_node_existing_rule_config(self, node_id, rule_node_id, role_id):
         '''
-        Set node rule
+        Get home node existing rule configuration data
         '''
-        return await self._access.post('home/rules/{0}'.format(template_name), create_payload)
+        return await self._access.get('home/nodes/{0}/rules/node/{1}/{2}'.format(node_id, rule_node_id, role_id))
 
-    async def get_rule_config(self, node_id, template_name, role_id):
+    async def get_home_node_template_rule_config(self, node_id, template_name, role_id):
         '''
-        Get node rule configuration data
+        Get node rule template configuration data
         '''
         return await self._access.get('home/nodes/{0}/rules/template/{1}/{2}'.format(node_id, template_name, role_id))
 
-    async def set_rule_config(self, rule_node_id, node_rule_data):
+    async def set_home_node_rule_config(self, rule_node_id, node_rule_data):
         '''
         Set node rule configuration data
         '''
-        self._access.put('home/rules/{0}'.format(rule_node_id), node_rule_data)
+        return await self._access.put('home/rules/{0}'.format(rule_node_id), node_rule_data)
 
-    async def get_rules(self, node_id):
+    async def get_home_node_new_rules(self, node_id):
         '''
-        Get node rules
+        Get node new rules
         '''
         return await self._access.get('home/nodes/{0}/rules'.format(node_id))
 
@@ -112,38 +124,68 @@ class Home:
         '''
         return await self._access.get('home/secmod/')
 
+    async def create_sms_number(self, sms_number_data):
+        '''
+        Create sms number
+        '''
+        return await self._access.post('home/sms/numbers', sms_number_data)
+
+    async def edit_sms_number(self, sms_number_id, sms_number_data):
+        '''
+        Edit sms number
+        '''
+        return await self._access.put('home/sms/numbers/{0}'.format(sms_number_id), sms_number_data)
+
     async def get_sms_numbers(self):
         '''
         Get sms numbers
         '''
         return await self._access.get('home/sms/numbers')
 
-    async def get_tile(self, tile_id):
+    async def send_sms_number_validation(self, sms_number_id, sms_validation_data):
         '''
-        Get the tile with provided id
+        Send sms number validation
+        '''
+        return await self._access.post('home/sms/numbers/{0}/send_validation_sms'.format(sms_number_id), sms_validation_data)
+
+    async def validate_sms_number(self, sms_number_id, sms_number_validation_data):
+        '''
+        Validate sms number
+        '''
+        return await self._access.post('home/sms/numbers/{0}/validate'.format(sms_number_id), sms_number_validation_data)
+
+    async def get_home_tile(self, tile_id):
+        '''
+        Get the home tile with provided id
         '''
         return await self._access.get('home/tileset/{0}'.format(tile_id))
 
-    async def get_tilesets(self):
+    async def get_home_tilesets(self):
         '''
-        Get the list of tileset
+        Get the list of home tileset
         '''
         return await self._access.get('home/tileset/all')
 
-    async def pairing_next(self, adapter_id, next_payload):
+    async def get_home_pairing_state(self, home_adapter_id):
+        '''
+        Get the current home pairing state
+        '''
+        return await self._access.get('home/pairing/{0}'.format(home_adapter_id))
+
+    async def next_home_pairing_step(self, home_adapter_id, next_pairing_step_payload):
+        '''
+        Next home pairing step
+        '''
+        return await self._access.post('home/pairing/{0}'.format(home_adapter_id), next_pairing_step_payload)
+
+    async def start_home_pairing_step(self, home_adapter_id, start_pairing_step_payload):
         '''
         Start pairing step
         '''
-        return await self._access.post('home/pairing/{0}'.format(adapter_id), next_payload)
+        return await self._access.post('home/pairing/{0}'.format(home_adapter_id), start_pairing_step_payload)
 
-    async def pairing_start(self, adapter_id, start_payload):
-        '''
-        Start pairing step
-        '''
-        return await self._access.post('home/pairing/{0}'.format(adapter_id), start_payload)
-
-    async def pairing_stop(self, adapter_id, stop_payload):
+    async def stop_home_pairing_step(self, home_adapter_id, stop_pairing_step_payload):
         '''
         Stop pairing
         '''
-        return await self._access.post('home/pairing/{0}'.format(adapter_id), stop_payload)
+        return await self._access.post('home/pairing/{0}'.format(home_adapter_id), stop_pairing_step_payload)

--- a/aiofreepybox/api/home.py
+++ b/aiofreepybox/api/home.py
@@ -82,9 +82,9 @@ class Home:
         '''
         return await self._access.get('camera')
 
-    async def get_camera_screenshot(self, camera_index=0, size=4, quality=5):
+    async def get_camera_snapshot(self, camera_index=0, size=4, quality=5):
         '''
-        Get camera screenshot
+        Get camera snapshot
         '''
         fbx_cameras = await self.get_camera()
         return await self._access.get(fbx_cameras[camera_index]['stream_url'].replace('stream.m3u8', 'snapshot.cgi?size={0}&quality={1}'.format(size, quality))[1:])

--- a/aiofreepybox/api/home.py
+++ b/aiofreepybox/api/home.py
@@ -10,17 +10,17 @@ class Home:
 
     create_home_node_rule_payload_schema = {
         'iconUrl': '',
-        'id': int,
+        'id': 0,
         'label': '',
         'name': '',
-        'role': int,
+        'role': 0,
         'roleLabel': '',
         'type': ''
     }
 
     node_rule_role_schema = {
-        'node': [int],
-        'role': int
+        'node': [0],
+        'role': 0
     }
 
     node_rule_configuration_data_schema = {
@@ -43,8 +43,8 @@ class Home:
     }
 
     next_pairing_step_payload_schema = {
-        'session': int,
-        'pageid': int,
+        'session': 0,
+        'pageid': 0,
         'fields': [object]
     }
 
@@ -55,7 +55,7 @@ class Home:
     }
 
     stop_pairing_step_payload_schema = {
-        'session': int,
+        'session': 0
     }
 
     async def del_home_adapter(self, home_adapter_id):

--- a/aiofreepybox/api/home.py
+++ b/aiofreepybox/api/home.py
@@ -82,6 +82,27 @@ class Home:
         '''
         return await self._access.get('camera')
 
+    async def get_camera_screenshot(self, camera_index=0, size=4, quality=5):
+        '''
+        Get camera screenshot
+        '''
+        fbx_cameras = await self.get_camera()
+        return await self._access.get(fbx_cameras[camera_index]['stream_url'].replace('stream.m3u8', 'snapshot.cgi?size={0}&quality={1}'.format(size, quality))[1:])
+
+    async def get_camera_stream_m3u8(self, camera_index=0, channel=2):
+        '''
+        Get camera stream
+        '''
+        fbx_cameras = await self.get_camera()
+        return await self._access.get(fbx_cameras[camera_index]['stream_url'].replace('stream.m3u8', 'stream.m3u8?channel={0}'.format(channel))[1:])
+
+    async def get_camera_ts(self, ts_name, camera_index=0):
+        '''
+        Get camera stream
+        '''
+        fbx_cameras = await self.get_camera()
+        return await self._access.get(fbx_cameras[camera_index]['stream_url'].replace('stream.m3u8', '{0}'.format(ts_name))[1:])
+
     async def get_home_endpoint_value(self, node_id, endpoint_id):
         '''
         Get home endpoint value

--- a/aiofreepybox/api/home.py
+++ b/aiofreepybox/api/home.py
@@ -180,12 +180,12 @@ class Home:
 
     async def start_home_pairing_step(self, home_adapter_id, start_pairing_step_payload):
         '''
-        Start pairing step
+        Start home pairing step
         '''
         return await self._access.post('home/pairing/{0}'.format(home_adapter_id), start_pairing_step_payload)
 
     async def stop_home_pairing_step(self, home_adapter_id, stop_pairing_step_payload):
         '''
-        Stop pairing
+        Stop home pairing
         '''
         return await self._access.post('home/pairing/{0}'.format(home_adapter_id), stop_pairing_step_payload)

--- a/aiofreepybox/api/home.py
+++ b/aiofreepybox/api/home.py
@@ -10,6 +10,12 @@ class Home:
         '''
         return await self._access.get('home/adapters/')
 
+    async def get_adapter(self, adapterid):
+        '''
+        Retrieve the list of registered HomeAdapters
+        '''
+        return await self._access.get('home/adapters/', adapterid)
+
     async def get_endpointvalue(self, nodeid, endpointid):
         '''
         Get endpoint value

--- a/aiofreepybox/api/home.py
+++ b/aiofreepybox/api/home.py
@@ -22,13 +22,13 @@ class Home:
         '''
         return await self._access.get('camera/')
 
-    async def get_endpointvalue(self, nodeid, endpointid):
+    async def get_endpoint_value(self, nodeid, endpointid):
         '''
         Get endpoint value
         '''
         return await self._access.get('home/endpoints/{0}/'.format(nodeid), endpointid)
 
-    async def set_endpointvalue(self, nodeid, endpointid, value):
+    async def set_endpoint_value(self, nodeid, endpointid, value):
         '''
         Set endpoint value
         '''
@@ -76,7 +76,7 @@ class Home:
         '''
         return await self._access.get('home/nodes/')
 
-    async def get_pairingstate(self, adapterid):
+    async def get_pairing_state(self, adapterid):
         '''
         Get the current pairing state
         '''
@@ -88,13 +88,13 @@ class Home:
         '''
         return await self._access.post('home/rules/', templatename, createpayload)
 
-    async def get_ruleconfig(self, nodeid, templatename, roleid):
+    async def get_rule_config(self, nodeid, templatename, roleid):
         '''
         Get node rule configuration data
         '''
         return await self._access.get('home/nodes/{0}/rules/template/{1}'.format(nodeid, templatename), roleid)
 
-    async def set_ruleconfig(self, rulenodeid, noderuledata):
+    async def set_rule_config(self, rulenodeid, noderuledata):
         '''
         Set node rule configuration data
         '''
@@ -112,7 +112,7 @@ class Home:
         '''
         return await self._access.get('home/secmod/')
 
-    async def get_smsnumbers(self):
+    async def get_sms_numbers(self):
         '''
         Get sms numbers
         '''

--- a/example.py
+++ b/example.py
@@ -24,13 +24,14 @@ async def demo():
     # example for the first time
     await fbx.open(host='abcdefgh.fbxos.fr', port=1234)
 
-    # Get a jpg snapshot from a camera
-    fbx_cam_jpg = await fbx.home.get_camera_snapshot()
+    if fbx.api_version == 'v6':
+        # Get a jpg snapshot from a camera
+        fbx_cam_jpg = await fbx.home.get_camera_snapshot()
 
-    # Get a TS stream from a camera
-    r = await fbx.home.get_camera_stream_m3u8()
-    m3u8_obj = m3u8.loads(await r.text())
-    fbx_ts = await fbx.home.get_camera_ts(m3u8_obj.files[0])
+        # Get a TS stream from a camera
+        r = await fbx.home.get_camera_stream_m3u8()
+        m3u8_obj = m3u8.loads(await r.text())
+        fbx_ts = await fbx.home.get_camera_ts(m3u8_obj.files[0])
 
     # Dump freebox configuration using system API
     # Extract temperature and mac address

--- a/example.py
+++ b/example.py
@@ -6,6 +6,8 @@ This example can be run safely as it won't change anything in your box configura
 '''
 
 import asyncio
+import m3u8
+
 from aiofreepybox import Freepybox
 
 
@@ -21,6 +23,14 @@ async def demo():
     # Be ready to authorize the application on the Freebox if you use this
     # example for the first time
     await fbx.open(host='abcdefgh.fbxos.fr', port=1234)
+
+    # Get a jpg screenshot from a camera
+    fbx_cam_jpg = await fbx.home.get_camera_screenshot()
+
+    # Get a TS stream from a camera
+    r = await fbx.home.get_camera_stream_m3u8()
+    m3u8_obj = m3u8.loads(await r.text())
+    fbx_ts = await fbx.home.get_camera_ts(m3u8_obj.files[0])
 
     # Dump freebox configuration using system API
     # Extract temperature and mac address

--- a/example.py
+++ b/example.py
@@ -24,8 +24,8 @@ async def demo():
     # example for the first time
     await fbx.open(host='abcdefgh.fbxos.fr', port=1234)
 
-    # Get a jpg screenshot from a camera
-    fbx_cam_jpg = await fbx.home.get_camera_screenshot()
+    # Get a jpg snapshot from a camera
+    fbx_cam_jpg = await fbx.home.get_camera_snapshot()
 
     # Get a TS stream from a camera
     r = await fbx.home.get_camera_stream_m3u8()


### PR DESCRIPTION
Initial support for the freebox os home API
API calls:
    del_home_adapter
    get_home_adapter
    get_home_adapters
    get_camera
    get_home_endpoint_value
    get_home_endpoint_values
    set_home_endpoint_value
    del_home_link
    get_home_link
    get_home_links
    del_home_node
    get_home_node
    edit_home_node
    get_home_nodes
    create_home_node_rule
    get_home_node_existing_rule_config
    get_home_node_template_rule_config
    set_home_node_rule_config
    get_home_node_new_rules
    get_secmod
    create_sms_number
    edit_sms_number
    get_sms_numbers
    send_sms_number_validation
    validate_sms_number
    get_home_tile
    get_home_tilesets
    get_home_pairing_state
    next_home_pairing_step
    start_home_pairing_step
    stop_home_pairing_step

